### PR TITLE
Locked game window, and added right click menu while game is running to resize

### DIFF
--- a/src/main/java/opendoja/host/DesktopHttpConnection.java
+++ b/src/main/java/opendoja/host/DesktopHttpConnection.java
@@ -252,16 +252,15 @@ public final class DesktopHttpConnection implements HttpConnection {
         if (rawUrl == null) {
             return null;
         }
-        String configuredHost = OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN, "").trim();
-        String requestHost = rawUrl.getHost();
-        if (configuredHost.isEmpty() || requestHost == null || !requestHost.equalsIgnoreCase(configuredHost)) {
+        String overrideHost = OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN, "").trim();
+        if (overrideHost.isEmpty() || rawUrl.getHost() == null) {
             return rawUrl;
         }
         try {
             return new URI(
                     rawUrl.getProtocol(),
                     rawUrl.getUserInfo(),
-                    "localhost",
+                    overrideHost,
                     rawUrl.getPort(),
                     rawUrl.getPath(),
                     rawUrl.getQuery(),

--- a/src/main/java/opendoja/host/DesktopHttpConnection.java
+++ b/src/main/java/opendoja/host/DesktopHttpConnection.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 
@@ -240,9 +242,32 @@ public final class DesktopHttpConnection implements HttpConnection {
 
     private static URL rewriteOutboundUrl(URL rawUrl) {
         try {
-            return OpenDoJaIdentity.replaceDefaultUserIdToken(rawUrl);
+            return OpenDoJaIdentity.replaceDefaultUserIdToken(rewriteConfiguredHost(rawUrl));
         } catch (IOException exception) {
             return rawUrl;
+        }
+    }
+
+    private static URL rewriteConfiguredHost(URL rawUrl) throws IOException {
+        if (rawUrl == null) {
+            return null;
+        }
+        String configuredHost = OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN, "").trim();
+        String requestHost = rawUrl.getHost();
+        if (configuredHost.isEmpty() || requestHost == null || !requestHost.equalsIgnoreCase(configuredHost)) {
+            return rawUrl;
+        }
+        try {
+            return new URI(
+                    rawUrl.getProtocol(),
+                    rawUrl.getUserInfo(),
+                    "localhost",
+                    rawUrl.getPort(),
+                    rawUrl.getPath(),
+                    rawUrl.getQuery(),
+                    rawUrl.getRef()).toURL();
+        } catch (URISyntaxException exception) {
+            throw new IOException("Could not rewrite outbound URL: " + rawUrl, exception);
         }
     }
 

--- a/src/main/java/opendoja/host/DesktopHttpConnectionProbe.java
+++ b/src/main/java/opendoja/host/DesktopHttpConnectionProbe.java
@@ -1,0 +1,79 @@
+package opendoja.host;
+
+import javax.microedition.io.Connector;
+import java.net.URL;
+
+public final class DesktopHttpConnectionProbe {
+    private DesktopHttpConnectionProbe() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        verifyMatchingHostRewritesToLocalhost();
+        verifyMismatchedHostIsLeftAlone();
+        verifyBlankOverrideDisablesRewriting();
+
+        System.out.println("Desktop HTTP connection probe OK");
+    }
+
+    private static void verifyMatchingHostRewritesToLocalhost() throws Exception {
+        withOverride("Example.com", () -> {
+            DesktopHttpConnection connection = new DesktopHttpConnection(
+                    new URL("http://example.com:8080/path/file?a=1#frag"),
+                    Connector.READ,
+                    false);
+            check("http://localhost:8080/path/file?a=1#frag".equals(connection.getURL()),
+                    "matching host should rewrite to localhost while preserving port, path, query, and fragment");
+        });
+    }
+
+    private static void verifyMismatchedHostIsLeftAlone() throws Exception {
+        withOverride("example.com", () -> {
+            DesktopHttpConnection connection = new DesktopHttpConnection(
+                    new URL("http://example.org/path"),
+                    Connector.READ,
+                    false);
+            check("http://example.org/path".equals(connection.getURL()),
+                    "non-matching hosts should not be rewritten");
+        });
+    }
+
+    private static void verifyBlankOverrideDisablesRewriting() throws Exception {
+        withOverride("", () -> {
+            DesktopHttpConnection connection = new DesktopHttpConnection(
+                    new URL("http://example.com/path"),
+                    Connector.READ,
+                    false);
+            check("http://example.com/path".equals(connection.getURL()),
+                    "blank override should leave requests unchanged");
+        });
+    }
+
+    private static void withOverride(String value, ThrowingRunnable runnable) throws Exception {
+        String previous = System.getProperty(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN);
+        try {
+            if (value == null) {
+                System.clearProperty(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN);
+            } else {
+                System.setProperty(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN, value);
+            }
+            runnable.run();
+        } finally {
+            if (previous == null) {
+                System.clearProperty(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN);
+            } else {
+                System.setProperty(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN, previous);
+            }
+        }
+    }
+
+    private static void check(boolean condition, String message) {
+        if (!condition) {
+            throw new IllegalStateException(message);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}

--- a/src/main/java/opendoja/host/DesktopHttpConnectionProbe.java
+++ b/src/main/java/opendoja/host/DesktopHttpConnectionProbe.java
@@ -8,32 +8,32 @@ public final class DesktopHttpConnectionProbe {
     }
 
     public static void main(String[] args) throws Exception {
-        verifyMatchingHostRewritesToLocalhost();
-        verifyMismatchedHostIsLeftAlone();
+        verifyConfiguredHostOverridesAnyRequestHost();
+        verifyConfiguredHostPreservesOriginalPortAndPath();
         verifyBlankOverrideDisablesRewriting();
 
         System.out.println("Desktop HTTP connection probe OK");
     }
 
-    private static void verifyMatchingHostRewritesToLocalhost() throws Exception {
-        withOverride("Example.com", () -> {
+    private static void verifyConfiguredHostOverridesAnyRequestHost() throws Exception {
+        withOverride("override.example", () -> {
             DesktopHttpConnection connection = new DesktopHttpConnection(
-                    new URL("http://example.com:8080/path/file?a=1#frag"),
+                    new URL("http://game.example/path/file?a=1#frag"),
                     Connector.READ,
                     false);
-            check("http://localhost:8080/path/file?a=1#frag".equals(connection.getURL()),
-                    "matching host should rewrite to localhost while preserving port, path, query, and fragment");
+            check("http://override.example/path/file?a=1#frag".equals(connection.getURL()),
+                    "configured host should replace any outbound request host");
         });
     }
 
-    private static void verifyMismatchedHostIsLeftAlone() throws Exception {
-        withOverride("example.com", () -> {
+    private static void verifyConfiguredHostPreservesOriginalPortAndPath() throws Exception {
+        withOverride("localhost", () -> {
             DesktopHttpConnection connection = new DesktopHttpConnection(
-                    new URL("http://example.org/path"),
+                    new URL("http://another-host.test:8080/path"),
                     Connector.READ,
                     false);
-            check("http://example.org/path".equals(connection.getURL()),
-                    "non-matching hosts should not be rewritten");
+            check("http://localhost:8080/path".equals(connection.getURL()),
+                    "configured host should preserve the original scheme, port, and path");
         });
     }
 

--- a/src/main/java/opendoja/host/DesktopLauncher.java
+++ b/src/main/java/opendoja/host/DesktopLauncher.java
@@ -2,6 +2,9 @@ package opendoja.host;
 
 import com.nttdocomo.ui.IApplication;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public final class DesktopLauncher {
     private DesktopLauncher() {
     }
@@ -35,21 +38,36 @@ public final class DesktopLauncher {
     }
 
     public static void main(String[] args) throws ClassNotFoundException {
-        if (args.length == 0) {
-            throw new IllegalArgumentException("Usage: DesktopLauncher <fully.qualified.IApplicationClass> [args...]");
+        List<String> effectiveArgs = new ArrayList<>();
+        for (int i = 0; i < args.length; i++) {
+            if ("--phone-model".equals(args[i])) {
+                if (i + 1 >= args.length) {
+                    throw new IllegalArgumentException(
+                            "Usage: DesktopLauncher [--phone-model <model>] <fully.qualified.IApplicationClass> [args...]");
+                }
+                OpenDoJaLaunchArgs.set(OpenDoJaLaunchArgs.MICROEDITION_PLATFORM_OVERRIDE, args[++i]);
+                continue;
+            }
+            effectiveArgs.add(args[i]);
+        }
+        if (effectiveArgs.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Usage: DesktopLauncher [--phone-model <model>] <fully.qualified.IApplicationClass> [args...]");
         }
         ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
         Class<?> rawClass = contextLoader == null
-                ? Class.forName(args[0], false, DesktopLauncher.class.getClassLoader())
-                : Class.forName(args[0], false, contextLoader);
+                ? Class.forName(effectiveArgs.get(0), false, DesktopLauncher.class.getClassLoader())
+                : Class.forName(effectiveArgs.get(0), false, contextLoader);
         if (!IApplication.class.isAssignableFrom(rawClass)) {
-            throw new IllegalArgumentException(args[0] + " does not extend com.nttdocomo.ui.IApplication");
+            throw new IllegalArgumentException(effectiveArgs.get(0) + " does not extend com.nttdocomo.ui.IApplication");
         }
         @SuppressWarnings("unchecked")
         Class<? extends IApplication> applicationClass = (Class<? extends IApplication>) rawClass;
-        String[] appArgs = new String[Math.max(0, args.length - 1)];
+        String[] appArgs = new String[Math.max(0, effectiveArgs.size() - 1)];
         if (appArgs.length > 0) {
-            System.arraycopy(args, 1, appArgs, 0, appArgs.length);
+            for (int i = 1; i < effectiveArgs.size(); i++) {
+                appArgs[i - 1] = effectiveArgs.get(i);
+            }
         }
         LaunchConfig config = LaunchConfig.builder(applicationClass)
                 .args(appArgs)

--- a/src/main/java/opendoja/host/DoJaRuntime.java
+++ b/src/main/java/opendoja/host/DoJaRuntime.java
@@ -803,6 +803,10 @@ public final class DoJaRuntime {
     }
 
     private String launchMicroeditionPlatform() {
+        String override = OpenDoJaLaunchArgs.microeditionPlatformOverride();
+        if (!override.isBlank()) {
+            return override;
+        }
         String targetDevice = config.parameters().get("TargetDevice");
         if (targetDevice != null && !targetDevice.isBlank()) {
             return targetDevice.trim();

--- a/src/main/java/opendoja/host/DoJaRuntime.java
+++ b/src/main/java/opendoja/host/DoJaRuntime.java
@@ -7,19 +7,27 @@ import com.nttdocomo.ui.Frame;
 import com.nttdocomo.ui.Graphics;
 import com.nttdocomo.ui.IApplication;
 
+import javax.swing.AbstractAction;
+import javax.swing.ButtonGroup;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JRadioButtonMenuItem;
 import javax.swing.Timer;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import java.awt.Color;
+import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
 import java.awt.RenderingHints;
+import java.awt.event.ActionEvent;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
@@ -44,6 +52,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
 public final class DoJaRuntime {
+    private static final int MAX_HOST_SCALE = 4;
     private static final ThreadLocal<LaunchConfig> PREPARED_LAUNCH = new ThreadLocal<>();
     private static final boolean TRACE_EVENTS = opendoja.host.OpenDoJaLaunchArgs.getBoolean(opendoja.host.OpenDoJaLaunchArgs.TRACE_EVENTS);
     private static final long MINIMUM_SELECT_PRESS_NANOS =
@@ -77,7 +86,7 @@ public final class DoJaRuntime {
     private final HostPanel hostPanel;
     private final ExternalFrameRenderer externalFrameRenderer;
     private final ScratchpadStorage scratchpadStorage;
-    private final int hostScale;
+    private volatile int hostScale;
     private volatile IApplication application;
     private JFrame frameWindow;
     private Frame currentFrame;
@@ -220,6 +229,25 @@ public final class DoJaRuntime {
 
     public int hostScale() {
         return hostScale;
+    }
+
+    public void setHostScale(int scale) {
+        int normalized = normalizeHostScale(scale);
+        if (hostScale == normalized) {
+            return;
+        }
+        hostScale = normalized;
+        if (SwingUtilities.isEventDispatchThread()) {
+            hostPanel.refreshPreferredSize();
+            repackWindow();
+            repaintWindow();
+        } else {
+            SwingUtilities.invokeLater(() -> {
+                hostPanel.refreshPreferredSize();
+                repackWindow();
+                repaintWindow();
+            });
+        }
     }
 
     public String sourceUrl() {
@@ -660,6 +688,7 @@ public final class DoJaRuntime {
                 }
             });
             window.add(hostPanel);
+            window.setResizable(false);
             window.pack();
             window.setLocationByPlatform(true);
             frameWindow = window;
@@ -668,6 +697,7 @@ public final class DoJaRuntime {
                 return;
             }
             window.setVisible(true);
+            repackWindow();
             hostPanel.requestFocusInWindow();
         });
     }
@@ -684,7 +714,11 @@ public final class DoJaRuntime {
     }
 
     private static int resolveHostScale(LaunchConfig config) {
-        return java.lang.Math.max(1, opendoja.host.OpenDoJaLaunchArgs.getInt(opendoja.host.OpenDoJaLaunchArgs.HOST_SCALE));
+        return normalizeHostScale(opendoja.host.OpenDoJaLaunchArgs.getInt(opendoja.host.OpenDoJaLaunchArgs.HOST_SCALE));
+    }
+
+    static int normalizeHostScale(int scale) {
+        return java.lang.Math.max(1, java.lang.Math.min(MAX_HOST_SCALE, scale));
     }
 
     private static boolean resolveExternalFrameEnabled(LaunchConfig config) {
@@ -695,8 +729,25 @@ public final class DoJaRuntime {
 
     private void repackWindow() {
         if (frameWindow != null) {
-            frameWindow.pack();
+            Dimension preferred = hostPreferredSizeForScale(hostScale);
+            hostPanel.setSize(preferred);
+            if (!frameWindow.isDisplayable()) {
+                frameWindow.pack();
+            } else {
+                java.awt.Insets insets = frameWindow.getInsets();
+                frameWindow.setSize(
+                        preferred.width + insets.left + insets.right,
+                        preferred.height + insets.top + insets.bottom);
+                frameWindow.validate();
+            }
         }
+    }
+
+    private Dimension hostPreferredSizeForScale(int scale) {
+        return externalFrameRenderer.layoutFor(
+                displayWidth(),
+                displayHeight(),
+                normalizeHostScale(scale)).preferredSize();
     }
 
 
@@ -830,6 +881,7 @@ public final class DoJaRuntime {
             setBackground(Color.BLACK);
             setOpaque(true);
             setFocusable(true);
+            installHostScalePopup();
             addFocusListener(new FocusAdapter() {
                 @Override
                 public void focusLost(FocusEvent e) {
@@ -880,10 +932,56 @@ public final class DoJaRuntime {
             return timer::stop;
         }
 
+        private void installHostScalePopup() {
+            MouseAdapter popupListener = new MouseAdapter() {
+                @Override
+                public void mousePressed(MouseEvent event) {
+                    maybeShowPopup(event);
+                }
+
+                @Override
+                public void mouseReleased(MouseEvent event) {
+                    maybeShowPopup(event);
+                }
+            };
+            addMouseListener(popupListener);
+        }
+
+        private void maybeShowPopup(MouseEvent event) {
+            if (!event.isPopupTrigger()) {
+                return;
+            }
+            JPopupMenu menu = buildHostScalePopup();
+            menu.show(event.getComponent(), event.getX(), event.getY());
+        }
+
+        private JPopupMenu buildHostScalePopup() {
+            JPopupMenu menu = new JPopupMenu();
+            ButtonGroup group = new ButtonGroup();
+            for (int scale = 1; scale <= MAX_HOST_SCALE; scale++) {
+                int selectedScale = scale;
+                JRadioButtonMenuItem item = new JRadioButtonMenuItem(new AbstractAction((scale * 100) + "%") {
+                    @Override
+                    public void actionPerformed(ActionEvent event) {
+                        runtime.setHostScale(selectedScale);
+                        HostPanel.this.requestFocusInWindow();
+                    }
+                });
+                item.setSelected(runtime.hostScale() == scale);
+                group.add(item);
+                menu.add(item);
+            }
+            return menu;
+        }
+
         private void refreshPreferredSize() {
             ExternalFrameLayout layout = runtime.externalFrameRenderer.layoutFor(
                     runtime.displayWidth(), runtime.displayHeight(), runtime.hostScale());
-            setPreferredSize(layout.preferredSize());
+            Dimension preferred = layout.preferredSize();
+            setPreferredSize(preferred);
+            setMinimumSize(preferred);
+            setMaximumSize(preferred);
+            setSize(preferred);
             revalidate();
         }
 

--- a/src/main/java/opendoja/host/JamLauncher.java
+++ b/src/main/java/opendoja/host/JamLauncher.java
@@ -10,6 +10,8 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -87,10 +89,21 @@ public final class JamLauncher {
     }
 
     public static void main(String[] args) throws Exception {
-        if (args.length != 1) {
-            throw new IllegalArgumentException("Usage: JamLauncher <path-to-jam>");
+        List<String> effectiveArgs = new ArrayList<>();
+        for (int i = 0; i < args.length; i++) {
+            if ("--phone-model".equals(args[i])) {
+                if (i + 1 >= args.length) {
+                    throw new IllegalArgumentException("Usage: JamLauncher [--phone-model <model>] <path-to-jam>");
+                }
+                OpenDoJaLaunchArgs.set(OpenDoJaLaunchArgs.MICROEDITION_PLATFORM_OVERRIDE, args[++i]);
+                continue;
+            }
+            effectiveArgs.add(args[i]);
         }
-        Path jamPath = Path.of(args[0]);
+        if (effectiveArgs.size() != 1) {
+            throw new IllegalArgumentException("Usage: JamLauncher [--phone-model <model>] <path-to-jam>");
+        }
+        Path jamPath = Path.of(effectiveArgs.get(0));
         LaunchCompatibility.reexecJamLauncherIfNeeded(jamPath);
         try {
             launch(jamPath, true);

--- a/src/main/java/opendoja/host/LaunchCompatibility.java
+++ b/src/main/java/opendoja/host/LaunchCompatibility.java
@@ -72,6 +72,7 @@ final class LaunchCompatibility {
             }
             command.add(arg);
         }
+        appendCurrentOpenDoJaProperties(command);
         command.add("-D" + OpenDoJaLaunchArgs.LAUNCH_COMPAT_APPLIED + "=true");
         if (disableExplicitGc) {
             // Games issue System.gc() liberally around UI/resource transitions as a lightweight
@@ -116,6 +117,7 @@ final class LaunchCompatibility {
             }
             command.add(arg);
         }
+        appendCurrentOpenDoJaProperties(command);
         command.add("-D" + OpenDoJaLaunchArgs.VERIFY_FALLBACK_APPLIED + "=true");
         command.add("-Xverify:none");
         command.add("-cp");
@@ -125,6 +127,22 @@ final class LaunchCompatibility {
             command.add(arg);
         }
         return command;
+    }
+
+    private static void appendCurrentOpenDoJaProperties(List<String> command) {
+        for (String name : System.getProperties().stringPropertyNames()) {
+            if (!name.startsWith("opendoja.")) {
+                continue;
+            }
+            if (name.equals(OpenDoJaLaunchArgs.LAUNCH_COMPAT_APPLIED)
+                    || name.equals(OpenDoJaLaunchArgs.VERIFY_FALLBACK_APPLIED)) {
+                continue;
+            }
+            String value = System.getProperty(name);
+            if (value != null) {
+                command.add("-D" + name + "=" + value);
+            }
+        }
     }
 
     private static String targetDefaultEncoding() {

--- a/src/main/java/opendoja/host/OpenDoJaLaunchArgs.java
+++ b/src/main/java/opendoja/host/OpenDoJaLaunchArgs.java
@@ -126,6 +126,8 @@ public final class OpenDoJaLaunchArgs {
     public static final String HOST_SCALE = "opendoja.hostScale";
     /** Hostname to force for outbound HTTP requests. */
     public static final String HTTP_OVERRIDE_DOMAIN = "opendoja.httpOverrideDomain";
+    /** Override value returned for microedition.platform during launch. */
+    public static final String MICROEDITION_PLATFORM_OVERRIDE = "opendoja.microeditionPlatformOverride";
     /** Simulated handset terminal ID returned to apps. */
     public static final String TERMINAL_ID = "opendoja.terminalId";
     /** Simulated user ID returned to apps. */
@@ -301,6 +303,7 @@ public final class OpenDoJaLaunchArgs {
             GPS_TRACKING_SUPPORTED,
             HOST_SCALE,
             HTTP_OVERRIDE_DOMAIN,
+            MICROEDITION_PLATFORM_OVERRIDE,
             TERMINAL_ID,
             USER_ID,
             INPUT_KEY_REPEAT_RELEASE_DEBOUNCE_MS,
@@ -378,6 +381,10 @@ public final class OpenDoJaLaunchArgs {
         return raw == null ? defaultValue : raw;
     }
 
+    public static String microeditionPlatformOverride() {
+        return normalizeMicroeditionPlatformOverride(get(MICROEDITION_PLATFORM_OVERRIDE, ""));
+    }
+
     public static boolean isEnabled(String property) {
         return getBoolean(property);
     }
@@ -448,6 +455,10 @@ public final class OpenDoJaLaunchArgs {
         return property != null && PROPERTY_SET.contains(property);
     }
 
+    public static String normalizeMicroeditionPlatformOverride(String candidate) {
+        return candidate == null ? "" : candidate.trim();
+    }
+
     public static String formatProperties() {
         StringJoiner joiner = new StringJoiner("\n", "Custom -Dopendoja.* properties:\n", "");
         for (String property : PROPERTIES) {
@@ -513,6 +524,7 @@ public final class OpenDoJaLaunchArgs {
         defaults.put(GPS_TRACKING_SUPPORTED, () -> "true");
         defaults.put(HOST_SCALE, () -> "1");
         defaults.put(HTTP_OVERRIDE_DOMAIN, () -> "");
+        defaults.put(MICROEDITION_PLATFORM_OVERRIDE, () -> "");
         defaults.put(TERMINAL_ID, OpenDoJaIdentity::defaultTerminalId);
         defaults.put(USER_ID, OpenDoJaIdentity::defaultUserId);
         defaults.put(INPUT_KEY_REPEAT_RELEASE_DEBOUNCE_MS, () -> "25");

--- a/src/main/java/opendoja/host/OpenDoJaLaunchArgs.java
+++ b/src/main/java/opendoja/host/OpenDoJaLaunchArgs.java
@@ -124,6 +124,8 @@ public final class OpenDoJaLaunchArgs {
     public static final String GPS_TRACKING_SUPPORTED = "opendoja.gpsTrackingSupported";
     /** Integer scale factor for the host viewport. */
     public static final String HOST_SCALE = "opendoja.hostScale";
+    /** Hostname to rewrite to localhost for outbound HTTP requests. */
+    public static final String HTTP_OVERRIDE_DOMAIN = "opendoja.httpOverrideDomain";
     /** Simulated handset terminal ID returned to apps. */
     public static final String TERMINAL_ID = "opendoja.terminalId";
     /** Simulated user ID returned to apps. */
@@ -298,6 +300,7 @@ public final class OpenDoJaLaunchArgs {
             GPS_SUPPORTED,
             GPS_TRACKING_SUPPORTED,
             HOST_SCALE,
+            HTTP_OVERRIDE_DOMAIN,
             TERMINAL_ID,
             USER_ID,
             INPUT_KEY_REPEAT_RELEASE_DEBOUNCE_MS,
@@ -509,6 +512,7 @@ public final class OpenDoJaLaunchArgs {
         defaults.put(GPS_SUPPORTED, () -> "true");
         defaults.put(GPS_TRACKING_SUPPORTED, () -> "true");
         defaults.put(HOST_SCALE, () -> "1");
+        defaults.put(HTTP_OVERRIDE_DOMAIN, () -> "");
         defaults.put(TERMINAL_ID, OpenDoJaIdentity::defaultTerminalId);
         defaults.put(USER_ID, OpenDoJaIdentity::defaultUserId);
         defaults.put(INPUT_KEY_REPEAT_RELEASE_DEBOUNCE_MS, () -> "25");

--- a/src/main/java/opendoja/host/OpenDoJaLaunchArgs.java
+++ b/src/main/java/opendoja/host/OpenDoJaLaunchArgs.java
@@ -124,7 +124,7 @@ public final class OpenDoJaLaunchArgs {
     public static final String GPS_TRACKING_SUPPORTED = "opendoja.gpsTrackingSupported";
     /** Integer scale factor for the host viewport. */
     public static final String HOST_SCALE = "opendoja.hostScale";
-    /** Hostname to rewrite to localhost for outbound HTTP requests. */
+    /** Hostname to force for outbound HTTP requests. */
     public static final String HTTP_OVERRIDE_DOMAIN = "opendoja.httpOverrideDomain";
     /** Simulated handset terminal ID returned to apps. */
     public static final String TERMINAL_ID = "opendoja.terminalId";

--- a/src/main/java/opendoja/host/ScratchpadStreams.java
+++ b/src/main/java/opendoja/host/ScratchpadStreams.java
@@ -77,6 +77,12 @@ public final class ScratchpadStreams {
         public int read(byte[] b, int off, int len) throws IOException {
             return file.read(b, off, len);
         }
+
+        @Override
+        public int available() throws IOException {
+            long remaining = file.length() - file.getFilePointer();
+            return (int) Math.min(remaining, Integer.MAX_VALUE);
+        }
     }
 
     private static final class RandomAccessFileOutputStream extends OutputStream {
@@ -128,6 +134,12 @@ public final class ScratchpadStreams {
                 remaining -= read;
             }
             return read;
+        }
+
+        @Override
+        public int available() throws IOException {
+            int delegateAvailable = delegate.available();
+            return (int) Math.min(delegateAvailable, remaining);
         }
     }
 

--- a/src/main/java/opendoja/launcher/LauncherPreferencesStore.java
+++ b/src/main/java/opendoja/launcher/LauncherPreferencesStore.java
@@ -16,6 +16,7 @@ final class LauncherPreferencesStore {
     private static final String TERMINAL_ID_KEY = "terminalId";
     private static final String USER_ID_KEY = "userId";
     private static final String FONT_TYPE_KEY = "fontType";
+    private static final String HTTP_OVERRIDE_DOMAIN_KEY = "httpOverrideDomain";
     private static final String DISABLE_BYTECODE_VERIFICATION_KEY = "disableBytecodeVerification";
     private static final String DISABLE_OS_DPI_SCALING_KEY = "disableOsDpiScaling";
     private static final String UPDATE_NOTIFICATIONS_PROMPTED_KEY = "updateNotificationsPrompted";
@@ -31,6 +32,8 @@ final class LauncherPreferencesStore {
         String storedTerminalId = preferences.get(TERMINAL_ID_KEY, OpenDoJaIdentity.defaultTerminalId());
         String storedUserId = preferences.get(USER_ID_KEY, OpenDoJaIdentity.defaultUserId());
         String storedFontType = preferences.get(FONT_TYPE_KEY, OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.FONT_TYPE));
+        String storedHttpOverrideDomain = preferences.get(HTTP_OVERRIDE_DOMAIN_KEY,
+                OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN, ""));
         boolean storedDisableBytecodeVerification = preferences.getBoolean(DISABLE_BYTECODE_VERIFICATION_KEY, false);
         boolean storedDisableOsDpiScaling = preferences.getBoolean(DISABLE_OS_DPI_SCALING_KEY, false);
         return new LauncherSettings(
@@ -39,6 +42,7 @@ final class LauncherPreferencesStore {
                 OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.TERMINAL_ID, storedTerminalId),
                 OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.USER_ID, storedUserId),
                 OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.FONT_TYPE, storedFontType),
+                OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN, storedHttpOverrideDomain),
                 storedDisableBytecodeVerification,
                 storedDisableOsDpiScaling);
     }
@@ -49,6 +53,7 @@ final class LauncherPreferencesStore {
         preferences.put(TERMINAL_ID_KEY, settings.terminalId());
         preferences.put(USER_ID_KEY, settings.userId());
         preferences.put(FONT_TYPE_KEY, settings.fontType());
+        preferences.put(HTTP_OVERRIDE_DOMAIN_KEY, settings.httpOverrideDomain());
         preferences.putBoolean(DISABLE_BYTECODE_VERIFICATION_KEY, settings.disableBytecodeVerification());
         preferences.putBoolean(DISABLE_OS_DPI_SCALING_KEY, settings.disableOsDpiScaling());
     }

--- a/src/main/java/opendoja/launcher/LauncherPreferencesStore.java
+++ b/src/main/java/opendoja/launcher/LauncherPreferencesStore.java
@@ -17,6 +17,7 @@ final class LauncherPreferencesStore {
     private static final String USER_ID_KEY = "userId";
     private static final String FONT_TYPE_KEY = "fontType";
     private static final String HTTP_OVERRIDE_DOMAIN_KEY = "httpOverrideDomain";
+    private static final String MICROEDITION_PLATFORM_OVERRIDE_KEY = "microeditionPlatformOverride";
     private static final String DISABLE_BYTECODE_VERIFICATION_KEY = "disableBytecodeVerification";
     private static final String DISABLE_OS_DPI_SCALING_KEY = "disableOsDpiScaling";
     private static final String UPDATE_NOTIFICATIONS_PROMPTED_KEY = "updateNotificationsPrompted";
@@ -34,6 +35,8 @@ final class LauncherPreferencesStore {
         String storedFontType = preferences.get(FONT_TYPE_KEY, OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.FONT_TYPE));
         String storedHttpOverrideDomain = preferences.get(HTTP_OVERRIDE_DOMAIN_KEY,
                 OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN, ""));
+        String storedMicroeditionPlatformOverride = preferences.get(MICROEDITION_PLATFORM_OVERRIDE_KEY,
+                OpenDoJaLaunchArgs.microeditionPlatformOverride());
         boolean storedDisableBytecodeVerification = preferences.getBoolean(DISABLE_BYTECODE_VERIFICATION_KEY, false);
         boolean storedDisableOsDpiScaling = preferences.getBoolean(DISABLE_OS_DPI_SCALING_KEY, false);
         return new LauncherSettings(
@@ -43,6 +46,7 @@ final class LauncherPreferencesStore {
                 OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.USER_ID, storedUserId),
                 OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.FONT_TYPE, storedFontType),
                 OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN, storedHttpOverrideDomain),
+                OpenDoJaLaunchArgs.get(OpenDoJaLaunchArgs.MICROEDITION_PLATFORM_OVERRIDE, storedMicroeditionPlatformOverride),
                 storedDisableBytecodeVerification,
                 storedDisableOsDpiScaling);
     }
@@ -54,6 +58,7 @@ final class LauncherPreferencesStore {
         preferences.put(USER_ID_KEY, settings.userId());
         preferences.put(FONT_TYPE_KEY, settings.fontType());
         preferences.put(HTTP_OVERRIDE_DOMAIN_KEY, settings.httpOverrideDomain());
+        preferences.put(MICROEDITION_PLATFORM_OVERRIDE_KEY, settings.microeditionPlatformOverride());
         preferences.putBoolean(DISABLE_BYTECODE_VERIFICATION_KEY, settings.disableBytecodeVerification());
         preferences.putBoolean(DISABLE_OS_DPI_SCALING_KEY, settings.disableOsDpiScaling());
     }

--- a/src/main/java/opendoja/launcher/LauncherProcessSupport.java
+++ b/src/main/java/opendoja/launcher/LauncherProcessSupport.java
@@ -83,6 +83,8 @@ final class LauncherProcessSupport {
         appendProperty(command, overriddenProperties, OpenDoJaLaunchArgs.USER_ID, settings.userId());
         appendProperty(command, overriddenProperties, OpenDoJaLaunchArgs.FONT_TYPE, settings.fontType());
         appendProperty(command, overriddenProperties, OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN, settings.httpOverrideDomain());
+        appendProperty(command, overriddenProperties, OpenDoJaLaunchArgs.MICROEDITION_PLATFORM_OVERRIDE,
+                settings.microeditionPlatformOverride());
         if (settings.disableOsDpiScaling()) {
             // Oracle's Java 2D troubleshooting docs recommend uiScale.enabled=false to disable
             // high-DPI scaling, while noting dpiaware=false no longer affects JDK 9+ on Windows.

--- a/src/main/java/opendoja/launcher/LauncherProcessSupport.java
+++ b/src/main/java/opendoja/launcher/LauncherProcessSupport.java
@@ -82,6 +82,7 @@ final class LauncherProcessSupport {
         appendProperty(command, overriddenProperties, OpenDoJaLaunchArgs.TERMINAL_ID, settings.terminalId());
         appendProperty(command, overriddenProperties, OpenDoJaLaunchArgs.USER_ID, settings.userId());
         appendProperty(command, overriddenProperties, OpenDoJaLaunchArgs.FONT_TYPE, settings.fontType());
+        appendProperty(command, overriddenProperties, OpenDoJaLaunchArgs.HTTP_OVERRIDE_DOMAIN, settings.httpOverrideDomain());
         if (settings.disableOsDpiScaling()) {
             // Oracle's Java 2D troubleshooting docs recommend uiScale.enabled=false to disable
             // high-DPI scaling, while noting dpiaware=false no longer affects JDK 9+ on Windows.

--- a/src/main/java/opendoja/launcher/LauncherSettings.java
+++ b/src/main/java/opendoja/launcher/LauncherSettings.java
@@ -3,6 +3,7 @@ package opendoja.launcher;
 import opendoja.audio.mld.MLDSynth;
 import opendoja.host.OpenDoJaIdentity;
 import opendoja.host.LaunchConfig;
+import opendoja.host.OpenDoJaLaunchArgs;
 
 record LauncherSettings(
         int hostScale,
@@ -11,6 +12,7 @@ record LauncherSettings(
         String userId,
         String fontType,
         String httpOverrideDomain,
+        String microeditionPlatformOverride,
         boolean disableBytecodeVerification,
         boolean disableOsDpiScaling) {
     LauncherSettings {
@@ -20,6 +22,7 @@ record LauncherSettings(
         userId = OpenDoJaIdentity.normalizeUserId(userId);
         fontType = LaunchConfig.FontType.normalizeId(fontType);
         httpOverrideDomain = normalizeHttpOverrideDomain(httpOverrideDomain);
+        microeditionPlatformOverride = OpenDoJaLaunchArgs.normalizeMicroeditionPlatformOverride(microeditionPlatformOverride);
     }
 
     static LauncherSettings defaults() {
@@ -27,6 +30,7 @@ record LauncherSettings(
                 OpenDoJaIdentity.defaultTerminalId(),
                 OpenDoJaIdentity.defaultUserId(),
                 LaunchConfig.FontType.BITMAP.id,
+                "",
                 "",
                 false,
                 false);

--- a/src/main/java/opendoja/launcher/LauncherSettings.java
+++ b/src/main/java/opendoja/launcher/LauncherSettings.java
@@ -10,6 +10,7 @@ record LauncherSettings(
         String terminalId,
         String userId,
         String fontType,
+        String httpOverrideDomain,
         boolean disableBytecodeVerification,
         boolean disableOsDpiScaling) {
     LauncherSettings {
@@ -18,6 +19,7 @@ record LauncherSettings(
         terminalId = OpenDoJaIdentity.normalizeTerminalId(terminalId);
         userId = OpenDoJaIdentity.normalizeUserId(userId);
         fontType = LaunchConfig.FontType.normalizeId(fontType);
+        httpOverrideDomain = normalizeHttpOverrideDomain(httpOverrideDomain);
     }
 
     static LauncherSettings defaults() {
@@ -25,6 +27,7 @@ record LauncherSettings(
                 OpenDoJaIdentity.defaultTerminalId(),
                 OpenDoJaIdentity.defaultUserId(),
                 LaunchConfig.FontType.BITMAP.id,
+                "",
                 false,
                 false);
     }
@@ -36,5 +39,12 @@ record LauncherSettings(
     private static String normalizeSynthId(String candidate) {
         MLDSynth synth = MLDSynth.fromId(candidate);
         return synth == null ? MLDSynth.DEFAULT.id : synth.id;
+    }
+
+    private static String normalizeHttpOverrideDomain(String candidate) {
+        if (candidate == null) {
+            return "";
+        }
+        return candidate.trim().toLowerCase(java.util.Locale.ROOT);
     }
 }

--- a/src/main/java/opendoja/launcher/LauncherSettingsController.java
+++ b/src/main/java/opendoja/launcher/LauncherSettingsController.java
@@ -59,7 +59,7 @@ final class LauncherSettingsController {
 
     String promptHttpOverrideDomain(Component parent, String currentValue) {
         String entered = promptValue(parent, "HTTP Host Override", currentValue,
-                "Enter the exact hostname to rewrite to localhost. Leave blank to disable.");
+                "Enter the hostname to use for all outbound HTTP requests. Leave blank to disable.");
         if (entered == null) {
             return null;
         }
@@ -67,7 +67,7 @@ final class LauncherSettingsController {
         if (normalized == null) {
             JOptionPane.showMessageDialog(
                     parent,
-                    "Enter only a hostname such as example.com. Do not include a scheme, path, query, or port.",
+                    "Enter only a hostname such as example.com or localhost. Do not include a scheme, path, query, or port.",
                     "HTTP Host Override",
                     JOptionPane.ERROR_MESSAGE);
             return null;

--- a/src/main/java/opendoja/launcher/LauncherSettingsController.java
+++ b/src/main/java/opendoja/launcher/LauncherSettingsController.java
@@ -4,7 +4,10 @@ import opendoja.audio.mld.MLDSynth;
 import opendoja.host.OpenDoJaIdentity;
 
 import java.awt.Component;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Locale;
 import javax.swing.JOptionPane;
 
 final class LauncherSettingsController {
@@ -54,6 +57,24 @@ final class LauncherSettingsController {
         return normalized;
     }
 
+    String promptHttpOverrideDomain(Component parent, String currentValue) {
+        String entered = promptValue(parent, "HTTP Host Override", currentValue,
+                "Enter the exact hostname to rewrite to localhost. Leave blank to disable.");
+        if (entered == null) {
+            return null;
+        }
+        String normalized = normalizeHttpOverrideDomain(entered);
+        if (normalized == null) {
+            JOptionPane.showMessageDialog(
+                    parent,
+                    "Enter only a hostname such as example.com. Do not include a scheme, path, query, or port.",
+                    "HTTP Host Override",
+                    JOptionPane.ERROR_MESSAGE);
+            return null;
+        }
+        return normalized;
+    }
+
     private String promptValue(Component parent, String title, String currentValue, String prompt) {
         String entered = (String) JOptionPane.showInputDialog(
                 parent,
@@ -64,5 +85,29 @@ final class LauncherSettingsController {
                 null,
                 currentValue);
         return entered == null ? null : entered;
+    }
+
+    private static String normalizeHttpOverrideDomain(String candidate) {
+        String normalized = candidate == null ? "" : candidate.trim();
+        if (normalized.isEmpty()) {
+            return "";
+        }
+        if (normalized.contains("://")
+                || normalized.contains("/")
+                || normalized.contains("?")
+                || normalized.contains("#")
+                || normalized.contains(":")) {
+            return null;
+        }
+        try {
+            URI uri = new URI("http://" + normalized);
+            String host = uri.getHost();
+            if (host == null || !normalized.equalsIgnoreCase(host)) {
+                return null;
+            }
+            return host.toLowerCase(Locale.ROOT);
+        } catch (URISyntaxException exception) {
+            return null;
+        }
     }
 }

--- a/src/main/java/opendoja/launcher/LauncherSettingsController.java
+++ b/src/main/java/opendoja/launcher/LauncherSettingsController.java
@@ -2,6 +2,7 @@ package opendoja.launcher;
 
 import opendoja.audio.mld.MLDSynth;
 import opendoja.host.OpenDoJaIdentity;
+import opendoja.host.OpenDoJaLaunchArgs;
 
 import java.awt.Component;
 import java.net.URI;
@@ -73,6 +74,15 @@ final class LauncherSettingsController {
             return null;
         }
         return normalized;
+    }
+
+    String promptMicroeditionPlatformOverride(Component parent, String currentValue) {
+        String entered = promptValue(parent, "Phone Model", currentValue,
+                "Enter the value to return for microedition.platform. Leave blank to use the JAM/default platform.");
+        if (entered == null) {
+            return null;
+        }
+        return OpenDoJaLaunchArgs.normalizeMicroeditionPlatformOverride(entered);
     }
 
     private String promptValue(Component parent, String title, String currentValue, String prompt) {

--- a/src/main/java/opendoja/launcher/OpenDoJaLauncher.java
+++ b/src/main/java/opendoja/launcher/OpenDoJaLauncher.java
@@ -8,6 +8,8 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class OpenDoJaLauncher {
     static final String APP_NAME = "openDoJa Launcher";
@@ -15,6 +17,7 @@ public final class OpenDoJaLauncher {
     static final String REPOSITORY_URL = "https://github.com/GrenderG/openDoJa";
     static final String LATEST_RELEASE_URL = REPOSITORY_URL + "/releases/latest";
     static final String GITHUB_LATEST_RELEASE_API_URL = "https://api.github.com/repos/GrenderG/openDoJa/releases/latest";
+    private static final String PHONE_MODEL_FLAG = "--phone-model";
     private static final String RUN_JAM_FLAG = "--run-jam";
     private static final String RUN_JAM_INTERNAL_FLAG = "--run-jam-internal";
     private static final String SPAWN_JAM_FLAG = "--spawn-jam";
@@ -32,7 +35,18 @@ public final class OpenDoJaLauncher {
     }
 
     private static void run(String[] args) throws Exception {
-        if (args.length == 0) {
+        List<String> effectiveArgs = new ArrayList<>();
+        for (int i = 0; i < args.length; i++) {
+            if (PHONE_MODEL_FLAG.equals(args[i])) {
+                if (i + 1 >= args.length) {
+                    throw new IllegalArgumentException("Usage: " + usageLine());
+                }
+                OpenDoJaLaunchArgs.set(OpenDoJaLaunchArgs.MICROEDITION_PLATFORM_OVERRIDE, args[++i]);
+                continue;
+            }
+            effectiveArgs.add(args[i]);
+        }
+        if (effectiveArgs.isEmpty() && args.length == 0) {
             configureLookAndFeel();
             SwingUtilities.invokeLater(() -> {
                 OpenDoJaLauncherFrame frame = new OpenDoJaLauncherFrame(
@@ -43,29 +57,29 @@ public final class OpenDoJaLauncher {
             });
             return;
         }
-        if (args.length == 1 && looksLikeJamPath(args[0])) {
-            GameLaunchSelection selection = new JamGameJarResolver().resolve(Path.of(args[0]));
+        if (effectiveArgs.size() == 1 && looksLikeJamPath(effectiveArgs.get(0))) {
+            GameLaunchSelection selection = new JamGameJarResolver().resolve(Path.of(effectiveArgs.get(0)));
             int exitCode = new LauncherProcessSupport().runInForeground(selection);
             System.exit(exitCode);
         }
-        if (args.length == 2 && RUN_JAM_FLAG.equals(args[0])) {
-            GameLaunchSelection selection = new JamGameJarResolver().resolve(Path.of(args[1]));
+        if (effectiveArgs.size() == 2 && RUN_JAM_FLAG.equals(effectiveArgs.get(0))) {
+            GameLaunchSelection selection = new JamGameJarResolver().resolve(Path.of(effectiveArgs.get(1)));
             int exitCode = new LauncherProcessSupport().runInForeground(selection);
             System.exit(exitCode);
         }
-        if (args.length == 2 && RUN_JAM_INTERNAL_FLAG.equals(args[0])) {
-            JamLauncher.main(new String[]{Path.of(args[1]).toString()});
+        if (effectiveArgs.size() == 2 && RUN_JAM_INTERNAL_FLAG.equals(effectiveArgs.get(0))) {
+            JamLauncher.main(new String[]{Path.of(effectiveArgs.get(1)).toString()});
             return;
         }
-        if (args.length == 2 && SPAWN_JAM_FLAG.equals(args[0])) {
-            GameLaunchSelection selection = new JamGameJarResolver().resolve(Path.of(args[1]));
+        if (effectiveArgs.size() == 2 && SPAWN_JAM_FLAG.equals(effectiveArgs.get(0))) {
+            GameLaunchSelection selection = new JamGameJarResolver().resolve(Path.of(effectiveArgs.get(1)));
             Process process = new LauncherProcessSupport().startInBackground(selection);
             OpenDoJaLog.configureIfUnset(OpenDoJaLog.Level.INFO);
             OpenDoJaLog.info(OpenDoJaLauncher.class,
                     "Spawned " + selection.jamPath() + " as pid " + process.pid());
             return;
         }
-        if (args.length == 1 && ("--help".equals(args[0]) || "-h".equals(args[0]))) {
+        if (effectiveArgs.size() == 1 && ("--help".equals(effectiveArgs.get(0)) || "-h".equals(effectiveArgs.get(0)))) {
             printUsage();
             return;
         }
@@ -89,7 +103,7 @@ public final class OpenDoJaLauncher {
     }
 
     private static String usageLine() {
-        return APP_NAME + " [<path-to-jam> | " + RUN_JAM_FLAG + " <path-to-jam> | "
+        return APP_NAME + " [" + PHONE_MODEL_FLAG + " <model>] [<path-to-jam> | " + RUN_JAM_FLAG + " <path-to-jam> | "
                 + SPAWN_JAM_FLAG + " <path-to-jam>]";
     }
 
@@ -97,6 +111,7 @@ public final class OpenDoJaLauncher {
         return usageLine()
                 + "\n\nPass custom runtime properties before -jar, for example:"
                 + "\n  java -D" + OpenDoJaLaunchArgs.HOST_SCALE + "=2 -jar target/opendoja-{version}.jar <game.jam>"
+                + "\n  java -jar target/opendoja-{version}.jar " + PHONE_MODEL_FLAG + " P900i <game.jam>"
                 + "\n\n" + OpenDoJaLaunchArgs.formatProperties();
     }
 

--- a/src/main/java/opendoja/launcher/OpenDoJaLauncherFrame.java
+++ b/src/main/java/opendoja/launcher/OpenDoJaLauncherFrame.java
@@ -345,7 +345,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
         ButtonGroup group = new ButtonGroup();
         for (int scale = 1; scale <= 4; scale++) {
             final int selectedScale = scale;
-            JRadioButtonMenuItem item = new JRadioButtonMenuItem(new AbstractAction(Integer.toString(scale)) {
+            JRadioButtonMenuItem item = new JRadioButtonMenuItem(new AbstractAction((scale * 100) + "%") {
                 @Override
                 public void actionPerformed(ActionEvent event) {
                     LauncherSettings current = jamLaunchService.loadSettings();

--- a/src/main/java/opendoja/launcher/OpenDoJaLauncherFrame.java
+++ b/src/main/java/opendoja/launcher/OpenDoJaLauncherFrame.java
@@ -121,6 +121,12 @@ final class OpenDoJaLauncherFrame extends JFrame {
                 updateUserId();
             }
         }));
+        settingsMenu.add(new JMenuItem(new AbstractAction("HTTP Host Override...") {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                updateHttpOverrideDomain();
+            }
+        }));
 
         JMenu helpMenu = new JMenu("Help");
         helpMenu.add(new JMenuItem(new AbstractAction("Keybinds") {
@@ -355,6 +361,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                             current.terminalId(),
                             current.userId(),
                             current.fontType(),
+                            current.httpOverrideDomain(),
                             current.disableBytecodeVerification(),
                             current.disableOsDpiScaling()));
                 }
@@ -381,6 +388,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                             current.terminalId(),
                             current.userId(),
                             fontType.id,
+                            current.httpOverrideDomain(),
                             current.disableBytecodeVerification(),
                             current.disableOsDpiScaling()));
                 }
@@ -407,6 +415,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                             current.terminalId(),
                             current.userId(),
                             current.fontType(),
+                            current.httpOverrideDomain(),
                             current.disableBytecodeVerification(),
                             current.disableOsDpiScaling()));
                 }
@@ -432,6 +441,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                     current.terminalId(),
                     current.userId(),
                     current.fontType(),
+                    current.httpOverrideDomain(),
                     disableBytecodeVerificationItem.isSelected(),
                     current.disableOsDpiScaling()));
         });
@@ -447,6 +457,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                     current.terminalId(),
                     current.userId(),
                     current.fontType(),
+                    current.httpOverrideDomain(),
                     current.disableBytecodeVerification(),
                     disableOsDpiScalingItem.isSelected()));
         });
@@ -467,6 +478,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                 updated,
                 current.userId(),
                 current.fontType(),
+                current.httpOverrideDomain(),
                 current.disableBytecodeVerification(),
                 current.disableOsDpiScaling()));
     }
@@ -483,6 +495,24 @@ final class OpenDoJaLauncherFrame extends JFrame {
                 current.terminalId(),
                 updated,
                 current.fontType(),
+                current.httpOverrideDomain(),
+                current.disableBytecodeVerification(),
+                current.disableOsDpiScaling()));
+    }
+
+    private void updateHttpOverrideDomain() {
+        LauncherSettings current = jamLaunchService.loadSettings();
+        String updated = settingsController.promptHttpOverrideDomain(this, current.httpOverrideDomain());
+        if (updated == null) {
+            return;
+        }
+        jamLaunchService.saveSettings(new LauncherSettings(
+                current.hostScale(),
+                current.synthId(),
+                current.terminalId(),
+                current.userId(),
+                current.fontType(),
+                updated,
                 current.disableBytecodeVerification(),
                 current.disableOsDpiScaling()));
     }

--- a/src/main/java/opendoja/launcher/OpenDoJaLauncherFrame.java
+++ b/src/main/java/opendoja/launcher/OpenDoJaLauncherFrame.java
@@ -127,6 +127,12 @@ final class OpenDoJaLauncherFrame extends JFrame {
                 updateHttpOverrideDomain();
             }
         }));
+        settingsMenu.add(new JMenuItem(new AbstractAction("Phone Model...") {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                updateMicroeditionPlatformOverride();
+            }
+        }));
 
         JMenu helpMenu = new JMenu("Help");
         helpMenu.add(new JMenuItem(new AbstractAction("Keybinds") {
@@ -362,6 +368,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                             current.userId(),
                             current.fontType(),
                             current.httpOverrideDomain(),
+                            current.microeditionPlatformOverride(),
                             current.disableBytecodeVerification(),
                             current.disableOsDpiScaling()));
                 }
@@ -389,6 +396,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                             current.userId(),
                             fontType.id,
                             current.httpOverrideDomain(),
+                            current.microeditionPlatformOverride(),
                             current.disableBytecodeVerification(),
                             current.disableOsDpiScaling()));
                 }
@@ -416,6 +424,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                             current.userId(),
                             current.fontType(),
                             current.httpOverrideDomain(),
+                            current.microeditionPlatformOverride(),
                             current.disableBytecodeVerification(),
                             current.disableOsDpiScaling()));
                 }
@@ -442,6 +451,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                     current.userId(),
                     current.fontType(),
                     current.httpOverrideDomain(),
+                    current.microeditionPlatformOverride(),
                     disableBytecodeVerificationItem.isSelected(),
                     current.disableOsDpiScaling()));
         });
@@ -458,6 +468,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                     current.userId(),
                     current.fontType(),
                     current.httpOverrideDomain(),
+                    current.microeditionPlatformOverride(),
                     current.disableBytecodeVerification(),
                     disableOsDpiScalingItem.isSelected()));
         });
@@ -479,6 +490,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                 current.userId(),
                 current.fontType(),
                 current.httpOverrideDomain(),
+                current.microeditionPlatformOverride(),
                 current.disableBytecodeVerification(),
                 current.disableOsDpiScaling()));
     }
@@ -496,6 +508,7 @@ final class OpenDoJaLauncherFrame extends JFrame {
                 updated,
                 current.fontType(),
                 current.httpOverrideDomain(),
+                current.microeditionPlatformOverride(),
                 current.disableBytecodeVerification(),
                 current.disableOsDpiScaling()));
     }
@@ -512,6 +525,25 @@ final class OpenDoJaLauncherFrame extends JFrame {
                 current.terminalId(),
                 current.userId(),
                 current.fontType(),
+                updated,
+                current.microeditionPlatformOverride(),
+                current.disableBytecodeVerification(),
+                current.disableOsDpiScaling()));
+    }
+
+    private void updateMicroeditionPlatformOverride() {
+        LauncherSettings current = jamLaunchService.loadSettings();
+        String updated = settingsController.promptMicroeditionPlatformOverride(this, current.microeditionPlatformOverride());
+        if (updated == null) {
+            return;
+        }
+        jamLaunchService.saveSettings(new LauncherSettings(
+                current.hostScale(),
+                current.synthId(),
+                current.terminalId(),
+                current.userId(),
+                current.fontType(),
+                current.httpOverrideDomain(),
                 updated,
                 current.disableBytecodeVerification(),
                 current.disableOsDpiScaling()));


### PR DESCRIPTION
The game window could previously be resized by dragging; it could break the aspect ratio and block the UI if resized incorrectly.

This will lock the game window and add a right-click menu so you can resize while the app is running.

Added a domain override features as well to assist with URLs that are hardecoded into applications. 