### PR TITLE
add Chinese font support for system font , prevent toufu

### DIFF
--- a/src/main/java/com/nttdocomo/ui/Font.java
+++ b/src/main/java/com/nttdocomo/ui/Font.java
@@ -686,7 +686,26 @@ public class Font {
     }
 
     private static String resolveFamily(int face) {
+        // Automatically determine font priority based on system language.
+        // This ensures better character support and point-matrix appearance for 
+        // Chinese language users in Mainland China, Hong Kong, Taiwan, and other regions.
+        // For default languages, prioritize bitmap fonts for the classic點陣 look.
+        boolean isChinese = Locale.getDefault().getLanguage().equalsIgnoreCase("zh");
+
         if (face == FACE_MONOSPACE) {
+            if (isChinese) {
+                return firstInstalled(
+                    "SimSun", "宋体", 
+                    "NSimSun", "新宋体", 
+                    "MingLiU", "細明體", 
+                    "PMingLiU", "新細明體", 
+                    "Microsoft YaHei", "微软雅黑", 
+                    "Noto Sans Mono CJK SC", 
+                    "MS Gothic", 
+                    java.awt.Font.MONOSPACED, 
+                    java.awt.Font.DIALOG
+                );
+            }
             return firstInstalled(
                     "MS Gothic",
                     "Noto Sans Mono CJK JP",
@@ -698,6 +717,20 @@ public class Font {
             );
         }
         if (face == FACE_PROPORTIONAL) {
+            if (isChinese) {
+                return firstInstalled(
+                    "SimSun", "宋体", 
+                    "NSimSun", "新宋体", 
+                    "MingLiU", "細明體", 
+                    "PMingLiU", "新細明體", 
+                    "Microsoft YaHei", "微软雅黑", 
+                    "Noto Sans CJK SC", 
+                    "MS UI Gothic", 
+                    "Meiryo UI", 
+                    java.awt.Font.DIALOG, 
+                    java.awt.Font.SANS_SERIF
+                );
+            }
             return firstInstalled(
                     "MS UI Gothic",
                     "MS PGothic",
@@ -713,6 +746,20 @@ public class Font {
                     "IPAGothic",
                     java.awt.Font.DIALOG,
                     java.awt.Font.SANS_SERIF
+            );
+        }
+        if (isChinese) {
+            return firstInstalled(
+                "SimSun", "宋体", 
+                "NSimSun", "新宋体", 
+                "MingLiU", "細明體", 
+                "PMingLiU", "新細明體", 
+                "Microsoft YaHei", "微软雅黑", 
+                "Noto Sans CJK SC", 
+                "MS UI Gothic", 
+                "Meiryo UI", 
+                java.awt.Font.DIALOG, 
+                java.awt.Font.SANS_SERIF
             );
         }
         return firstInstalled(


### PR DESCRIPTION
Thanks to the openDoJa project! Besides making it easier to run Keitai games, I’ve found that this project is a huge help for creating Chinese fan translations.

Since openDoJa supports system fonts, fan translators don’t have to worry about missing characters or manually modifying the original bitmap fonts dumped from old phones. This is a game-changer for Chinese support. However, the current default system font is "MS Gothic," which does not support many Chinese-specific characters. If we use Chinese text in a translation, it often results in "tofu" (□□).

While Chinese and Japanese characters overlap significantly, MS Gothic alone isn't enough to express full Chinese sentences. Although the current code includes Noto Sans, it requires users to download it manually, and it lacks the classic "bitmap look" of original Keitai games. Utilizing pre-installed Windows fonts is a much better approach.

I’ve implemented a locale check to prioritize fonts based on the system language. Here is why I chose this method instead of just appending to the list:
1. **Why not just append Chinese fonts to the end?** Chinese Windows also includes MS Gothic. If MS Gothic remains at the top, the system will still pick it and we still get "tofu."
2. **Why not put SimSun at the very top for everyone?** SimSun supports Japanese characters too, but the glyphs are slightly different from MS Gothic. I don't want to affect the experience for Japanese users who prefer the original look.

The best solution is to detect the user's locale. If a Chinese language is detected, the engine will prioritize **SimSun (宋体)**. It features built-in bitmaps at small sizes that perfectly match the aesthetic of Keitai games, supports the full Chinese character set, and ensures fan translations are tofu-free.
<img width="911" height="401" alt="1" src="https://github.com/user-attachments/assets/88d6b5f7-7529-40b7-9423-7ca08bce44f0" />
