### PR TITLE
add jitpack settings

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - sdk install java 22-open
+  - sdk use java 22-open


### PR DESCRIPTION
i'd like to use openDoja as a library.

because openDoja has a very nice audio library for japanese feature phones.

but currently, on jitpack, openDoja build fails.
so i add the jitpack settings.

this made openDoja build on jitpack succeed.
then openDoja will be opened as a maven repository.

https://github.com/umjammer/openDoJa/releases/tag/0.2.5.6 (the same hash as this pull request)
https://jitpack.io/#umjammer/openDoja/ (0.2.5.6 build is succeed on jitpack)

https://jitpack.io/#GrenderG/openDoja (jitpack repository for your project)